### PR TITLE
Fix escaping of shell commands

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -24,7 +24,7 @@ optionsParser =
     info' :: Parser a -> String -> ParserInfo a
     info' p desc = info
         (helper <*> p)
-        (fullDesc <> progDesc desc)
+        (fullDesc <> progDesc desc <> noIntersperse)
 
     parser' :: Parser Command
     parser' =
@@ -48,7 +48,8 @@ optionsParser =
 main :: IO ()
 main = do
     withGlobalTracing do
-        Command {..} <- execParser optionsParser
+        let parserPrefs = defaultPrefs{ prefMultiSuffix = "..." }
+        Command {..} <- customExecParser parserPrefs optionsParser
         case commandSubCommand of
             Exec execArgs ->
                 runExecArgs execArgs

--- a/hotel-california.cabal
+++ b/hotel-california.cabal
@@ -82,6 +82,7 @@ library
     , hs-opentelemetry-vendor-honeycomb
     , http-types
     , optparse-applicative
+    , posix-escape
     , text
     , time
     , typed-process


### PR DESCRIPTION
Before this change, the `hotel` executable wouldn't handle spaces in arguments correctly.  A simple example is:

```bash
$ hotel exec echo ' a'
```

Before this change that would print:

```
a
```

… and after this change it correctly prints:

```
 a
```