### PR TITLE
Add support for propagating "baggage"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
-## Unreleased
+## 0.0.3.0 - 2023-09-18
+
+- [#13](https://github.com/parsonsmatt/hotel-california/pull/13)
+    - The `hotel` command will now propagate the `BAGGAGE` environment variable,
+      according to the [W3C working draft](https://www.w3.org/TR/baggage/),
+      similar how it already propagates `TRACEPARENT` and `TRACESTATE`.
 
 ## 0.0.2.0 - 2023-09-15
 

--- a/hotel-california.cabal
+++ b/hotel-california.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           hotel-california
-version:        0.0.2.0
+version:        0.0.3.0
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/hotel-california#readme>
 homepage:       https://github.com/parsonsmatt/hotel-california#readme
 bug-reports:    https://github.com/parsonsmatt/hotel-california/issues

--- a/src/HotelCalifornia/Tracing/TraceParent.hs
+++ b/src/HotelCalifornia/Tracing/TraceParent.hs
@@ -1,16 +1,22 @@
 -- | This module defines the type of 'TraceParent' which can be parsed
-module HotelCalifornia.Tracing.TraceParent where
+module HotelCalifornia.Tracing.TraceParent
+    ( spanContextFromEnvironment
+    , baggageFromEnvironment
+    , spanContextToEnvironment
+    , setParentSpanFromEnvironment
+    ) where
 
-import Data.Foldable (for_)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text as Text
+import OpenTelemetry.Baggage (Baggage)
 import OpenTelemetry.Propagator.W3CTraceContext
 import OpenTelemetry.Trace.Core (SpanContext, isRemote, wrapSpanContext, Span)
 import System.Environment
 import OpenTelemetry.Context.ThreadLocal
 import qualified OpenTelemetry.Context as Ctxt
+import qualified OpenTelemetry.Propagator.W3CBaggage as W3CBaggage
 
 -- | This function looks up the @TRACEPARENT@ and @TRACECONTEXT@ environment
 -- variables and returns a @'Maybe' 'SpanContext'@ constructed from them.
@@ -19,9 +25,21 @@ spanContextFromEnvironment = do
     mtraceParent <- lookupEnvBS "TRACEPARENT"
     mtraceContext <- lookupEnvBS "TRACESTATE"
     pure $ decodeSpanContext mtraceParent mtraceContext
-  where
-    lookupEnvBS :: String -> IO (Maybe BS.ByteString)
-    lookupEnvBS str = fmap (TE.encodeUtf8 . Text.pack) <$> lookupEnv str
+
+-- | This function looks up the @BAGGAGE@ environment variable and returns a
+-- @'Maybe' 'Baggage'@ constructed from that.
+baggageFromEnvironment :: IO (Maybe Baggage)
+baggageFromEnvironment = do
+    mBaggageBytes <- lookupEnvBS "BAGGAGE"
+
+    let mBaggage = do
+            baggageBytes <- mBaggageBytes
+            W3CBaggage.decodeBaggage baggageBytes
+
+    pure mBaggage
+
+lookupEnvBS :: String -> IO (Maybe BS.ByteString)
+lookupEnvBS str = fmap (TE.encodeUtf8 . Text.pack) <$> lookupEnv str
 
 -- | This function takes the given 'Span' and converts it into a list of
 -- environment variables consisting of:
@@ -29,21 +47,46 @@ spanContextFromEnvironment = do
 -- @
 -- [ ( "TRACEPARENT", traceParent)
 -- , ( "TRACESTATE", traceState)
+-- , ( "BAGGAGE", traceParent)
 -- ]
 -- @
 spanContextToEnvironment :: Span -> IO [(String, String)]
-spanContextToEnvironment spanContext = do
-    (traceParent, traceState) <- encodeSpanContext spanContext
-    pure
-        [ ("TRACEPARENT", BS8.unpack traceParent)
-        , ("TRACESTATE", BS8.unpack traceState)
-        ]
+spanContextToEnvironment span_ = do
+    (traceParent, traceState) <- encodeSpanContext span_
 
+    context <- getContext
+
+    let baggageVariables =
+            case Ctxt.lookupBaggage context of
+                Just baggage ->
+                    [("BAGGAGE", BS8.unpack (W3CBaggage.encodeBaggage baggage))]
+                Nothing ->
+                    []
+
+    pure
+        (   [ ("TRACEPARENT", BS8.unpack traceParent)
+            , ("TRACESTATE", BS8.unpack traceState)
+            ]
+        <>  baggageVariables
+        )
 
 -- | This function should be called after you've initialized and attached the
 -- thread local 'Context'.
 setParentSpanFromEnvironment :: IO ()
 setParentSpanFromEnvironment = do
-    mspanContext <- spanContextFromEnvironment
-    for_ mspanContext \spanContext -> do
-        adjustContext $ Ctxt.insertSpan (wrapSpanContext (spanContext {isRemote = True}))
+    mSpanContext <- spanContextFromEnvironment
+    mBaggage <- baggageFromEnvironment
+
+    let insertSpanContext =
+            case mSpanContext of
+                Nothing ->
+                    id
+                Just spanContext ->
+                    Ctxt.insertSpan (wrapSpanContext spanContext{ isRemote = True })
+
+    let insertBaggage =
+            case mBaggage of
+                Nothing      -> id
+                Just baggage -> Ctxt.insertBaggage baggage
+
+    adjustContext (insertBaggage . insertSpanContext)


### PR DESCRIPTION
See: https://www.w3.org/TR/baggage/

While studying the `traceparent`/`tracestatus`-related logic, I noticed that there was a parallel W3C standard for a baggage header that one can propagate through a trace.

We're extremely unlikely to ever use this, but I figured it couldn't hurt to add this.