### PR TITLE
Add `--attribute` to set span attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently, the only supported command is `exec`
 $ hotel exec --help
 Usage: hotel exec [-s|--span-name SPAN_NAME]
                   [-i|--set-sigint-status SPAN_STATUS]
+                  [-a|--attribute KEY=VALUE]...
                   (COMMAND [ARGUMENT]... | --shell SCRIPT)
 
   Execute the given command with tracing enabled
@@ -23,6 +24,7 @@ Available options:
   -i,--set-sigint-status SPAN_STATUS
                            The status reported when the process is killed with
                            SIGINT.
+  -a,--attribute KEY=VALUE A string attribute to add to the span.
   --shell SCRIPT           Run an arbitrary shell script instead of running an
                            executable command
 ```

--- a/hotel-california.cabal
+++ b/hotel-california.cabal
@@ -87,6 +87,7 @@ library
     , time
     , typed-process
     , unliftio
+    , unordered-containers
   default-language: Haskell2010
 
 executable hotel


### PR DESCRIPTION
This allows `hotel exec --attribute my-key=my-value -- ...`. For now, only string attributes are supported.