### PR TITLE
Record exit status and command attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to the
 
 ## Unreleased
 
+- [#19](https://github.com/parsonsmatt/hotel-california/pull/19/)
+    - Record the command's exit status (`process.exit_status`) and command
+      attributes.
+    - This replaces the default `process.executable.name` and related attributes
+      set by `hs-opentelemetry`.
+
 ## 0.0.4.0 - 2024-01-26
 
 - [#14](https://github.com/parsonsmatt/hotel-california/pull/14/)

--- a/hotel-california.cabal
+++ b/hotel-california.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
 name:           hotel-california
-version:        0.0.4.0
+version:        0.0.5.0
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/hotel-california#readme>
 homepage:       https://github.com/parsonsmatt/hotel-california#readme
 bug-reports:    https://github.com/parsonsmatt/hotel-california/issues
@@ -30,8 +30,8 @@ library
       HotelCalifornia.Tracing
       HotelCalifornia.Tracing.TraceParent
   other-modules:
-      HotelCalifornia.Which
       Paths_hotel_california
+      HotelCalifornia.Which
   hs-source-dirs:
       src
   default-extensions:
@@ -75,6 +75,8 @@ library
   build-depends:
       base >=4.7 && <5
     , bytestring
+    , directory
+    , filepath
     , hs-opentelemetry-api >=0.1.0.0
     , hs-opentelemetry-exporter-otlp
     , hs-opentelemetry-propagator-w3c
@@ -89,8 +91,6 @@ library
     , typed-process
     , unliftio
     , unordered-containers
-    , filepath
-    , directory
   default-language: Haskell2010
 
 executable hotel
@@ -140,6 +140,8 @@ executable hotel
   build-depends:
       base >=4.7 && <5
     , bytestring
+    , directory
+    , filepath
     , hotel-california
     , hs-opentelemetry-api >=0.1.0.0
     , hs-opentelemetry-exporter-otlp
@@ -205,6 +207,8 @@ test-suite hotel-california-test
   build-depends:
       base >=4.7 && <5
     , bytestring
+    , directory
+    , filepath
     , hotel-california
     , hs-opentelemetry-api >=0.1.0.0
     , hs-opentelemetry-exporter-otlp

--- a/hotel-california.cabal
+++ b/hotel-california.cabal
@@ -30,6 +30,7 @@ library
       HotelCalifornia.Tracing
       HotelCalifornia.Tracing.TraceParent
   other-modules:
+      HotelCalifornia.Which
       Paths_hotel_california
   hs-source-dirs:
       src
@@ -88,6 +89,8 @@ library
     , typed-process
     , unliftio
     , unordered-containers
+    , filepath
+    , directory
   default-language: Haskell2010
 
 executable hotel

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hotel-california
-version:             0.0.4.0
+version:             0.0.5.0
 github:              "parsonsmatt/hotel-california"
 license:             BSD3
 author:              Matt Parsons
@@ -36,6 +36,8 @@ dependencies:
 - typed-process
 - unliftio
 - unordered-containers
+- filepath
+- directory
 
 default-extensions:
 - BlockArguments
@@ -88,6 +90,9 @@ ghc-options:
 
 library:
   source-dirs: src
+  other-modules:
+    - Paths_hotel_california
+    - HotelCalifornia.Which
 
 executables:
   hotel:

--- a/src/HotelCalifornia/Which.hs
+++ b/src/HotelCalifornia/Which.hs
@@ -1,0 +1,81 @@
+-- | Like @which(1)@ but portable.
+--
+-- Modified from @shelly@.
+module HotelCalifornia.Which (which) where
+
+import Data.Text qualified as Text
+import System.FilePath (splitDirectories, (</>), isAbsolute, searchPathSeparator)
+import System.Directory (doesFileExist, getPermissions, getPermissions, executable)
+import System.Environment (getEnv)
+import Control.Exception (catch)
+import Data.Maybe (isJust)
+
+-- | Get a full path to an executable by looking at the @PATH@ environement
+-- variable. Windows normally looks in additional places besides the
+-- @PATH@: this does not duplicate that behavior.
+which :: FilePath -> IO (Maybe FilePath)
+which path =
+  if isAbsolute path || startsWithDot splitOnDirs
+  then checkFile
+  else lookupPath
+  where
+    splitOnDirs = splitDirectories path
+
+    -- 'startsWithDot' receives as input the result of 'splitDirectories',
+    -- which will include the dot (\".\") as its first element only if this
+    -- is a path of the form \"./foo/bar/baz.sh\". Check for example:
+    --
+    -- > import System.FilePath as FP
+    -- > FP.splitDirectories "./test/data/hello.sh"
+    -- [".","test","data","hello.sh"]
+    -- > FP.splitDirectories ".hello.sh"
+    -- [".hello.sh"]
+    -- > FP.splitDirectories ".test/hello.sh"
+    -- [".test","hello.sh"]
+    -- > FP.splitDirectories ".foo"
+    -- [".foo"]
+    --
+    -- Note that earlier versions of Shelly used
+    -- \"system-filepath\" which also has a 'splitDirectories'
+    -- function, but it returns \"./\" as its first argument,
+    -- so we pattern match on both for backward-compatibility.
+    startsWithDot (".":_)  = True
+    startsWithDot _ = False
+
+    checkFile :: IO (Maybe FilePath)
+    checkFile = do
+        exists <- doesFileExist path
+        pure $
+            if exists
+            then Just path
+            else Nothing
+
+    lookupPath :: IO (Maybe FilePath)
+    lookupPath = (pathDirs >>=) $ findMapM $ \dir -> do
+        let fullPath = dir </> path
+        isExecutable' <- isExecutable fullPath
+        pure $
+            if isExecutable'
+            then Just fullPath
+            else Nothing
+
+    pathDirs =
+        (map Text.unpack
+          . filter (not . Text.null)
+          . Text.split (== searchPathSeparator)
+          . Text.pack)
+         `fmap` getEnv "PATH"
+
+
+isExecutable :: FilePath -> IO Bool
+isExecutable f = (executable `fmap` getPermissions f) `catch` (\(_ :: IOError) -> return False)
+
+
+-- | A monadic @findMap@, taken from the @MissingM@ package
+findMapM :: Monad m => (a -> m (Maybe b)) -> [a] -> m (Maybe b)
+findMapM _ [] = return Nothing
+findMapM f (x:xs) = do
+    mb <- f x
+    if (isJust mb)
+      then return mb
+      else findMapM f xs


### PR DESCRIPTION
Adds extra span attributes, including:

- `process.exit_status`
- `process.executable.name`
- `process.executable.path`
- `process.command_args`

See: https://github.com/iand675/hs-opentelemetry/blob/02653bbfa286579be13cef17701da454ac3dfce1/api/src/OpenTelemetry/Resource/Process.hs#L61-L68