### PR TITLE
improve help text when no subcommand is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ and this project adheres to the
 
 ## Unreleased
 
+## 0.0.6.1 - 2025-03-07
+
+- [#21](https://github.com/parsonsmatt/hotel-california/pull/21)
+  - Add more detail to the program description
+
 ## 0.0.6.0 - 2024-03-28
 
-- [#20](https://github.com/parsonsmatt/hotel-california/pull/19/)
+- [#20](https://github.com/parsonsmatt/hotel-california/pull/20/)
     - Reduce Honeycomb target initialization timeout from 3 seconds to 1 second.
     - `withGlobalTracing` now expects a callback that accepts the honeycomb target.
     - Executable bypasses OTEL operations if Honeycomb target cannot be initialized.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@ import Paths_hotel_california (version)
 import HotelCalifornia.Exec
 import HotelCalifornia.Tracing (withGlobalTracing)
 import Options.Applicative
-import Options.Applicative.Help.Pretty (Doc, cat, hardline)
+import Options.Applicative.Help.Pretty (Doc, vsep)
 
 data Command = Command
     { commandGlobalOptions :: GlobalOptions
@@ -18,12 +18,12 @@ data SubCommand
     = Exec ExecArgs
 
 programDescription :: Doc
-programDescription = cat [
-    "`hotel-california` is a tool for OTel tracing of shell scripts, inspired by `otel-cli`.",
-    "For help with a command, say `hotel COMMAND --help`. Currently, the only supported command is `exec`."
-   ]
-   <> hardline <> hardline
-   <> "Check out the repository any time you like at https://github.com/parsonsmatt/hotel-california."
+programDescription = vsep
+  [ "`hotel-california` is a tool for OTel tracing of shell scripts, inspired by `otel-cli`."
+  , "For help with a command, say `hotel COMMAND --help`. Currently, the only supported command is `exec`."
+  , ""
+  , "Check out the repository any time you like at https://github.com/parsonsmatt/hotel-california."
+  ]
 
 optionsParser :: ParserInfo Command
 optionsParser =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,7 +20,7 @@ data SubCommand
 programDescription :: Doc
 programDescription = cat [
     "`hotel-california` is a tool for OTel tracing of shell scripts, inspired by `otel-cli`.",
-    "For subcommand help, say `hotel SUBCOMMAND --help. Currently, the only supported subcommand is `exec`."
+    "For help with a command, say `hotel COMMAND --help`. Currently, the only supported command is `exec`."
    ]
    <> hardline <> hardline
    <> "Check out the repository any time you like at https://github.com/parsonsmatt/hotel-california."

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,7 @@ import Paths_hotel_california (version)
 import HotelCalifornia.Exec
 import HotelCalifornia.Tracing (withGlobalTracing)
 import Options.Applicative
+import Options.Applicative.Help.Pretty (Doc, cat, hardline)
 
 data Command = Command
     { commandGlobalOptions :: GlobalOptions
@@ -16,15 +17,23 @@ data GlobalOptions = GlobalOptions
 data SubCommand
     = Exec ExecArgs
 
+programDescription :: Doc
+programDescription = cat [
+    "`hotel-california` is a tool for OTel tracing of shell scripts, inspired by `otel-cli`.",
+    "For subcommand help, say `hotel SUBCOMMAND --help. Currently, the only supported subcommand is `exec`."
+   ]
+   <> hardline <> hardline
+   <> "Check out the repository any time you like at https://github.com/parsonsmatt/hotel-california."
+
 optionsParser :: ParserInfo Command
 optionsParser =
-    info' parser' "Welcome to `hotel-california`"
+    info' parser' programDescription
   where
   -- thanks danidiaz for the blog post
-    info' :: Parser a -> String -> ParserInfo a
-    info' p desc = info
+    info' :: Parser a -> Doc -> ParserInfo a
+    info' p descDoc = info
         (helper <*> p)
-        (fullDesc <> progDesc desc <> noIntersperse)
+        (fullDesc <> progDescDoc (Just descDoc) <> noIntersperse)
 
     parser' :: Parser Command
     parser' =

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hotel-california
-version:             0.0.6.0
+version:             0.0.6.1
 github:              "parsonsmatt/hotel-california"
 license:             BSD3
 author:              Matt Parsons


### PR DESCRIPTION
This is for Mercury issue [DUX-3056](https://linear.app/mercury/issue/DUX-3056/better-help-for-hotel-california).

Old output:
<img width="1201" alt="Screenshot 2025-03-07 at 8 21 29 AM" src="https://github.com/user-attachments/assets/eca0e671-d942-485c-a31f-bc19b773405e" />

New output:
<img width="1172" alt="Screenshot 2025-03-07 at 8 31 41 AM" src="https://github.com/user-attachments/assets/ebe2b97a-f229-4e3c-9829-8146f21343a7" />