### PR TITLE
OpenTelemetry: stop looking at Honeycomb for whether tracing is on

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,11 +1,11 @@
 module Main where
 
 import Data.Version (showVersion)
-import Paths_hotel_california (version)
 import HotelCalifornia.Exec
 import HotelCalifornia.Tracing (withGlobalTracing)
 import Options.Applicative
 import Options.Applicative.Help.Pretty (Doc, vsep)
+import Paths_hotel_california (version)
 
 data Command = Command
     { commandGlobalOptions :: GlobalOptions
@@ -18,47 +18,56 @@ data SubCommand
     = Exec ExecArgs
 
 programDescription :: Doc
-programDescription = vsep
-  [ "`hotel-california` is a tool for OTel tracing of shell scripts, inspired by `otel-cli`."
-  , "For help with a command, say `hotel COMMAND --help`. Currently, the only supported command is `exec`."
-  , ""
-  , "Check out the repository any time you like at https://github.com/parsonsmatt/hotel-california."
-  ]
+programDescription =
+    vsep
+        [ "`hotel-california` is a tool for OTel tracing of shell scripts, inspired by `otel-cli`."
+        , "For help with a command, say `hotel COMMAND --help`. Currently, the only supported command is `exec`."
+        , ""
+        , "Check out the repository any time you like at https://github.com/parsonsmatt/hotel-california."
+        ]
 
 optionsParser :: ParserInfo Command
 optionsParser =
     info' parser' programDescription
   where
-  -- thanks danidiaz for the blog post
+    -- thanks danidiaz for the blog post
     info' :: Parser a -> Doc -> ParserInfo a
-    info' p descDoc = info
-        (helper <*> p)
-        (fullDesc <> progDescDoc (Just descDoc) <> noIntersperse)
+    info' p descDoc =
+        info
+            (helper <*> p)
+            (fullDesc <> progDescDoc (Just descDoc) <> noIntersperse)
 
     parser' :: Parser Command
     parser' =
         Command
             <$> generalOptionsParser
             <*> subCommandParser
-            <**> simpleVersioner (showVersion version)
+                <**> simpleVersioner (showVersion version)
 
     generalOptionsParser =
         pure GlobalOptions
 
     subCommandParser :: Parser SubCommand
     subCommandParser =
-        subparser $ foldMap command'
-                    [ ("exec", "Execute the given command with tracing enabled", Exec <$> parseExecArgs)
-                    ]
+        subparser $
+            foldMap
+                command'
+                [
+                    ( "exec"
+                    , "Execute the given command with tracing enabled"
+                    , Exec <$> parseExecArgs
+                    )
+                ]
 
-    command' (cmdName,desc,parser) =
+    command' (cmdName, desc, parser) =
         command cmdName (info' parser desc)
 
 main :: IO ()
 main = do
     withGlobalTracing $ \tracingEnabled -> do
-        let parserPrefs = defaultPrefs{ prefMultiSuffix = "..." }
-        Command {..} <- customExecParser parserPrefs optionsParser
+        let
+            parserPrefs = defaultPrefs{prefMultiSuffix = "..."}
+        Command{..} <- customExecParser parserPrefs optionsParser
         case commandSubCommand of
             Exec execArgs ->
                 if tracingEnabled

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -56,11 +56,11 @@ optionsParser =
 
 main :: IO ()
 main = do
-    withGlobalTracing $ \mTarget -> do
+    withGlobalTracing $ \tracingEnabled -> do
         let parserPrefs = defaultPrefs{ prefMultiSuffix = "..." }
         Command {..} <- customExecParser parserPrefs optionsParser
         case commandSubCommand of
             Exec execArgs ->
-                case mTarget of
-                    Just _target -> runExecArgs execArgs
-                    Nothing -> runNoTracing $ execArgsSubprocess execArgs
+                if tracingEnabled
+                    then runExecArgs execArgs
+                    else runNoTracing $ execArgsSubprocess execArgs

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,4 @@
-source-repository-package
-    type: git
-    location: https://github.com/parsonsmatt/hs-opentelemetry
-    tag: da04eede49e659fde15ce8382e9294a6d6732930
-    subdir: exporters/otlp
-
 packages: .
+allow-newer:
+    -- Ian has been notified.
+    hs-opentelemetry-utils-exceptions:hs-opentelemetry-api

--- a/hotel-california.cabal
+++ b/hotel-california.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -77,12 +77,11 @@ library
     , bytestring
     , directory
     , filepath
-    , hs-opentelemetry-api >=0.1.0.0
+    , hs-opentelemetry-api >=0.3.0.0
     , hs-opentelemetry-exporter-otlp
     , hs-opentelemetry-propagator-w3c
-    , hs-opentelemetry-sdk >=0.0.3.6
+    , hs-opentelemetry-sdk >=0.1.0.1
     , hs-opentelemetry-utils-exceptions
-    , hs-opentelemetry-vendor-honeycomb
     , http-types
     , optparse-applicative
     , posix-escape
@@ -143,12 +142,11 @@ executable hotel
     , directory
     , filepath
     , hotel-california
-    , hs-opentelemetry-api >=0.1.0.0
+    , hs-opentelemetry-api >=0.3.0.0
     , hs-opentelemetry-exporter-otlp
     , hs-opentelemetry-propagator-w3c
-    , hs-opentelemetry-sdk >=0.0.3.6
+    , hs-opentelemetry-sdk >=0.1.0.1
     , hs-opentelemetry-utils-exceptions
-    , hs-opentelemetry-vendor-honeycomb
     , http-types
     , optparse-applicative
     , posix-escape
@@ -210,12 +208,11 @@ test-suite hotel-california-test
     , directory
     , filepath
     , hotel-california
-    , hs-opentelemetry-api >=0.1.0.0
+    , hs-opentelemetry-api >=0.3.0.0
     , hs-opentelemetry-exporter-otlp
     , hs-opentelemetry-propagator-w3c
-    , hs-opentelemetry-sdk >=0.0.3.6
+    , hs-opentelemetry-sdk >=0.1.0.1
     , hs-opentelemetry-utils-exceptions
-    , hs-opentelemetry-vendor-honeycomb
     , http-types
     , optparse-applicative
     , posix-escape

--- a/package.yaml
+++ b/package.yaml
@@ -22,12 +22,11 @@ description:         Please see the README on GitHub at <https://github.com/pars
 dependencies:
 - base >= 4.7 && < 5
 - bytestring
-- hs-opentelemetry-api >= 0.1.0.0
+- hs-opentelemetry-api >= 0.3.0.0
 - hs-opentelemetry-exporter-otlp
 - hs-opentelemetry-propagator-w3c
-- hs-opentelemetry-sdk >= 0.0.3.6
+- hs-opentelemetry-sdk >= 0.1.0.1
 - hs-opentelemetry-utils-exceptions
-- hs-opentelemetry-vendor-honeycomb
 - http-types
 - optparse-applicative
 - posix-escape

--- a/src/HotelCalifornia/Tracing.hs
+++ b/src/HotelCalifornia/Tracing.hs
@@ -4,9 +4,8 @@ module HotelCalifornia.Tracing
     ) where
 
 import Control.Monad
-import qualified Data.ByteString.Char8 as BS8
+import Data.List (isPrefixOf)
 import Data.Text (Text)
-import Data.Time
 import HotelCalifornia.Tracing.TraceParent
 import OpenTelemetry.Context as Context hiding (lookup)
 import OpenTelemetry.Context.ThreadLocal (attachContext)
@@ -21,7 +20,7 @@ import OpenTelemetry.Trace hiding
        , inSpan''
        )
 import qualified OpenTelemetry.Trace as Trace
-import qualified OpenTelemetry.Vendor.Honeycomb as Honeycomb
+import System.Environment (getEnvironment)
 import UnliftIO
 
 -- | Initialize the global tracing provider for the application and run an action
@@ -29,27 +28,27 @@ import UnliftIO
 --   up the provider afterwards.
 --
 --   This also sets up an empty context (creating a new trace ID).
-withGlobalTracing :: MonadUnliftIO m => (Maybe Honeycomb.HoneycombTarget -> m a) -> m a
+--
+--   The callback receives 'True' when an OTLP exporter is configured (any
+--   @OTEL_EXPORTER_*@ env-var is set) and tracing has been initialized, and
+--   'False' otherwise — in which case the caller should bypass tracing.
+withGlobalTracing :: MonadUnliftIO m => (Bool -> m a) -> m a
 withGlobalTracing act = do
     void $ attachContext Context.empty
     liftIO setParentSpanFromEnvironment
-    bracket (liftIO initializeGlobalTracerProvider) shutdownTracerProvider $ \_ -> do
-        -- note: this is not in a span since we don't have a root span yet so it
-        -- would not wind up in the trace in a helpful way anyway
-        mTarget <-
-          Honeycomb.getOrInitializeHoneycombTargetInContext initializationTimeout
-            `catch` \(e :: SomeException) -> do
-              -- we are too early in initialization to be able to use a normal logger,
-              -- but this needs to get out somehow.
-              --
-              -- honeycomb links are not load-bearing, so we let them just not come
-              -- up if the API fails.
-              liftIO . BS8.hPutStrLn stderr $ "error setting up Honeycomb trace links: " <> (BS8.pack $ displayException e)
-              pure Nothing
+    hasOtelExporter <- liftIO otelExporterConfigured
+    if hasOtelExporter
+        then bracket (liftIO initializeGlobalTracerProvider) shutdownTracerProvider $ \_ ->
+            act True
+        else act False
 
-        act mTarget
+-- | Returns 'True' iff any @OTEL_EXPORTER_*@ environment variable is set with
+--   a non-empty value. Used to decide whether to initialize tracing at all.
+otelExporterConfigured :: IO Bool
+otelExporterConfigured =
+    any isOtelExporter <$> getEnvironment
   where
-    initializationTimeout = secondsToNominalDiffTime 1
+    isOtelExporter (k, v) = "OTEL_EXPORTER_" `isPrefixOf` k && not (null v)
 
 globalTracer :: MonadIO m => m Tracer
 globalTracer = getGlobalTracerProvider >>= \tp -> pure $ makeTracer tp "hotel-california" tracerOptions

--- a/src/HotelCalifornia/Tracing.hs
+++ b/src/HotelCalifornia/Tracing.hs
@@ -10,16 +10,16 @@ import HotelCalifornia.Tracing.TraceParent
 import OpenTelemetry.Context as Context hiding (lookup)
 import OpenTelemetry.Context.ThreadLocal (attachContext)
 import OpenTelemetry.Trace hiding
-       ( SpanKind(..)
-       , SpanStatus(..)
-       , addAttribute
-       , addAttributes
-       , createSpan
-       , inSpan
-       , inSpan'
-       , inSpan''
-       )
-import qualified OpenTelemetry.Trace as Trace
+    ( SpanKind (..)
+    , SpanStatus (..)
+    , addAttribute
+    , addAttributes
+    , createSpan
+    , inSpan
+    , inSpan'
+    , inSpan''
+    )
+import OpenTelemetry.Trace qualified as Trace
 import System.Environment (getEnvironment)
 import UnliftIO
 
@@ -32,7 +32,7 @@ import UnliftIO
 --   The callback receives 'True' when an OTLP exporter is configured (any
 --   @OTEL_EXPORTER_*@ env-var is set) and tracing has been initialized, and
 --   'False' otherwise — in which case the caller should bypass tracing.
-withGlobalTracing :: MonadUnliftIO m => (Bool -> m a) -> m a
+withGlobalTracing :: (MonadUnliftIO m) => (Bool -> m a) -> m a
 withGlobalTracing act = do
     void $ attachContext Context.empty
     liftIO setParentSpanFromEnvironment
@@ -50,8 +50,9 @@ otelExporterConfigured =
   where
     isOtelExporter (k, v) = "OTEL_EXPORTER_" `isPrefixOf` k && not (null v)
 
-globalTracer :: MonadIO m => m Tracer
-globalTracer = getGlobalTracerProvider >>= \tp -> pure $ makeTracer tp "hotel-california" tracerOptions
+globalTracer :: (MonadIO m) => m Tracer
+globalTracer =
+    getGlobalTracerProvider >>= \tp -> pure $ makeTracer tp "hotel-california" tracerOptions
 
 inSpan' :: (MonadUnliftIO m) => Text -> (Span -> m a) -> m a
 inSpan' spanName =
@@ -61,7 +62,8 @@ inSpanWith :: (MonadUnliftIO m) => Text -> SpanArguments -> m a -> m a
 inSpanWith spanName args action =
     inSpanWith' spanName args \_ -> action
 
-inSpanWith' :: (MonadUnliftIO m) => Text -> SpanArguments -> (Span -> m a) -> m a
+inSpanWith'
+    :: (MonadUnliftIO m) => Text -> SpanArguments -> (Span -> m a) -> m a
 inSpanWith' spanName args action = do
     tr <- globalTracer
     Trace.inSpan'' tr spanName args action

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,7 +6,6 @@ packages:
 
 extra-deps:
   - posix-escape-0.1
-  - honeycomb-0.1.0.1
   - hs-opentelemetry-api-0.1.0.0
     # - hs-opentelemetry-exporter-otlp-0.0.1.4
   - hs-opentelemetry-otlp-0.0.1.0
@@ -14,7 +13,6 @@ extra-deps:
   - hs-opentelemetry-propagator-w3c-0.0.1.3
   - hs-opentelemetry-sdk-0.0.3.6
   - hs-opentelemetry-utils-exceptions-0.2.0.0
-  - hs-opentelemetry-vendor-honeycomb-0.0.1.1
   - thread-utils-context-0.3.0.3
   - thread-utils-finalizers-0.1.0.0
   - github: parsonsmatt/hs-opentelemetry


### PR DESCRIPTION
There exist other tracing providers than Honeycomb, and even with Honeycomb, you might be going through an OTel collector which doesn't require having the API keys present.